### PR TITLE
Updates Enchantment industry fabric 1.19.2 to patch F

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,8 @@ repositories {
 	maven { url = "https://api.modrinth.com/maven" } // LazyDFU
 	maven { url = "https://maven.terraformersmc.com/releases/" } // Mod Menu
 	maven { url = "https://mvn.devos.one/snapshots/" } // Create, Porting Lib, Forge Tags, Milk Lib, Registrate
-	maven { url = "https://cursemaven.com" } // Forge Config API Port
+	maven { url = "https://mvn.devos.one/releases/" } // Porting Lib Releases
+	maven { url = "https://raw.githubusercontent.com/Fuzss/modresources/main/maven/" } // Forge Config API Port
 	maven { url = "https://maven.jamieswhiteshirt.com/libs-release" } // Reach Entity Attributes
 	maven { url = "https://jitpack.io/" } // Mixin Extras, Fabric ASM
 	maven { url = "https://maven.tterrag.com/" } // Flywheel

--- a/changelog/1.0.2.md
+++ b/changelog/1.0.2.md
@@ -1,0 +1,3 @@
+## CEI Fabric 1.0.2
+### Update
+- Updates compatibility for Create patch F

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.jvmargs=-Xmx2G
 # Mod Info
 maven_group = plus.dragons.createenchantmentindustry
 archives_base_name = create_enchantment_industry
-mod_version = 1.0.1.b
+mod_version = 1.0.2
 
 minecraft_version = 1.19.2
 
@@ -20,7 +20,7 @@ parchment_version = 2022.11.27
 
 # Create
 # https://modrinth.com/mod/create-fabric/versions
-create_version = 0.5.1-c-build.1160+mc1.19.2
+create_version = 0.5.1-f-build.1334+mc1.19.2
 
 # Development QOL
 # Create supports all 3 recipe viewers: JEI, REI, and EMI. This decides which is enabled at runtime.
@@ -38,4 +38,4 @@ modmenu_version = 4.1.2
 # LazyDFU - https://modrinth.com/mod/lazydfu/versions
 lazydfu_version = 0.1.3
 # DragonLib - https://github.com/DragonsPlusMinecraft/CreateDragonLib-Fabric
-dragonlib_version = 1.0.1
+dragonlib_version = 1.0.2


### PR DESCRIPTION
This is the follow up PR to https://github.com/DragonsPlusMinecraft/CreateDragonLib-Fabric/pull/4.

Let me know if I missed anything!