### PR TITLE
Fix copying written book and increment generation

### DIFF
--- a/src/main/java/plus/dragons/createenchantmentindustry/content/contraptions/enchanting/printer/PrintEntries.java
+++ b/src/main/java/plus/dragons/createenchantmentindustry/content/contraptions/enchanting/printer/PrintEntries.java
@@ -159,9 +159,12 @@ public class PrintEntries {
         @Override
         public ItemStack print(ItemStack target, ItemStack material) {
             var ret = target.copy();
-            if(CeiConfigs.SERVER.copyingWrittenBookAlwaysGetOriginalVersion.get())
-                target.getOrCreateTag().putInt("generation", 0);
-            else target.getOrCreateTag().putInt("generation", 1);
+            if (!CeiConfigs.SERVER.copyingWrittenBookAlwaysGetOriginalVersion.get()) {
+				var tag = ret.getOrCreateTag();
+				int generation = tag.getInt("generation");
+				if (generation <= 1)
+					tag.putInt("generation", generation + 1);
+			}
             return ret;
         }
 


### PR DESCRIPTION
At the moment, copying written books using printer behaves in a seemingly bugged way:
* With `copyingWrittenBookAlwaysGetOriginalVersion` set to `true`, copying any written book sets the *original*'s generation to 0 (original).
* With `copyingWrittenBookAlwaysGetOriginalVersion` set to `false`, copying any written book sets the *original*'s generation to 1 (copy of original).

I am not sure if this behaviour is intended or not, but it is definitely inconsistent and counter-intuitive. In normal Minecraft, copying a written book degrades the *result*, not the source. There are no other situations in this mod where using a printer on something would modify the actual item stored in the printer. It is also in conflict with the description of `copyingWrittenBookAlwaysGetOriginalVersion`:
```toml
#Whether or not copying a written book always get original version. Setting it to false let you always get copy version of the book.
```

My best guess is that it is an error ‒ the code copies `target` (the item in the printer) and stores it as `ret`, but then proceeds to modify `target` without affecting `ret` at all. As a result, a perfect copy of the original is outputted, while the original is modified in-place.

This pull request changes the existing behaviour to the following:
* With `copyingWrittenBookAlwaysGetOriginalVersion` set to `true`, a perfect copy of the original is returned. No modifications to `generation` are necessary at all, ensuring that the actual original version is preserved, as stated by the description of the setting.
* With `copyingWrittenBookAlwaysGetOriginalVersion` set to `false`, the result's `generation` is *incremented* for values 0 (original) and 1 (copy of original), going to 1 and 2, respectively, while it is unchanged for other generations. This makes the printer more in-line with Minecraft's behaviour of copying books, while the advantage of being able to copy books in generation 2 (copy of copy) stays the same.