### PR TITLE
fix: prevent buckets from wasting experience

### DIFF
--- a/src/main/java/plus/dragons/createenchantmentindustry/foundation/mixin/FillingBySpoutMixin.java
+++ b/src/main/java/plus/dragons/createenchantmentindustry/foundation/mixin/FillingBySpoutMixin.java
@@ -9,15 +9,17 @@ import com.simibubi.create.content.fluids.spout.FillingBySpout;
 
 import io.github.fabricators_of_create.porting_lib.fluids.FluidStack;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
 import net.minecraft.world.level.Level;
 import plus.dragons.createenchantmentindustry.content.contraptions.fluids.experience.MendingBySpout;
+import plus.dragons.createenchantmentindustry.entry.CeiFluids;
 
 @Mixin(value = FillingBySpout.class)
 public class FillingBySpoutMixin {
     @Inject(method = "canItemBeFilled", at = @At(value = "INVOKE", target = "Lcom/simibubi/create/content/fluids/transfer/GenericItemFilling;canItemBeFilled(Lnet/minecraft/world/level/Level;Lnet/minecraft/world/item/ItemStack;)Z"), cancellable = true)
     private static void canItemBeMended(Level world, ItemStack stack, CallbackInfoReturnable<Boolean> cir) {
-        if (MendingBySpout.canItemBeMended(world, stack))
-            cir.setReturnValue(true);
+        if (!MendingBySpout.canItemBeMended(world, stack)) return; // We don't handle non-mendable items
+        cir.setReturnValue(!stack.is(Items.BUCKET)); // If it's a mendable, we don't allow buckets
     }
 
     @Inject(method = "getRequiredAmountForItem",
@@ -25,9 +27,16 @@ public class FillingBySpoutMixin {
 					target = "Lcom/simibubi/create/content/fluids/transfer/GenericItemFilling;getRequiredAmountForItem(Lnet/minecraft/world/level/Level;Lnet/minecraft/world/item/ItemStack;Lio/github/fabricators_of_create/porting_lib/fluids/FluidStack;)J"),
 			cancellable = true)
     private static void getRequiredXpAmountForItem(Level world, ItemStack stack, FluidStack availableFluid, CallbackInfoReturnable<Long> cir) {
-        int amount = MendingBySpout.getRequiredAmountForItem(world, stack, availableFluid);
-        if (amount > 0)
-            cir.setReturnValue((long) amount);
+        if (!CeiFluids.EXPERIENCE.is(availableFluid.getFluid()))
+            return; // We don't handle non-mendable items
+
+        if (stack.is(Items.BUCKET)) {
+            cir.setReturnValue(-1L); // If it's a mendable, we don't allow buckets
+        } else {
+            int amount = MendingBySpout.getRequiredAmountForItem(world, stack, availableFluid);
+            if (amount > 0)
+                cir.setReturnValue((long) amount);
+        }
     }
 
     @Inject(method = "fillItem",
@@ -35,8 +44,14 @@ public class FillingBySpoutMixin {
 					target = "Lcom/simibubi/create/content/fluids/transfer/GenericItemFilling;fillItem(Lnet/minecraft/world/level/Level;JLnet/minecraft/world/item/ItemStack;Lio/github/fabricators_of_create/porting_lib/fluids/FluidStack;)Lnet/minecraft/world/item/ItemStack;"),
 			cancellable = true)
     private static void mendItem(Level world, long requiredAmount, ItemStack stack, FluidStack availableFluid, CallbackInfoReturnable<ItemStack> cir) {
-        ItemStack result = MendingBySpout.mendItem(world, (int) requiredAmount, stack, availableFluid);
-        if (result != null)
-            cir.setReturnValue(result);
+        if (!CeiFluids.EXPERIENCE.is(availableFluid.getFluid()))
+            return; // We don't handle non-mendable items
+        if (stack.is(Items.BUCKET)) {
+            cir.setReturnValue(ItemStack.EMPTY); // If it's a mendable, we don't allow buckets
+        } else {
+            ItemStack result = MendingBySpout.mendItem(world, (int) requiredAmount, stack, availableFluid);
+            if (result != null)
+                cir.setReturnValue(result);
+        }
     }
 }


### PR DESCRIPTION
Fixes #75 

Now buckets are disallowed to be filled, thus stopping the XP waste.

Implementing Liquid XP buckets might need another feature PR.